### PR TITLE
Add method to refresh csrf token

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,15 +48,13 @@
     "js-sha3": "^0.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.0",
-    "@typescript-eslint/eslint-plugin": "^3.3.0",
-    "@typescript-eslint/parser": "^3.3.0",
     "@rsksmart/rif-id-ethr-did": "0.1.0",
     "@rsksmart/rif-id-mnemonic": "0.1.0",
+    "@types/jest": "^26.0.0",
     "@types/mockdate": "^2.0.0",
     "@types/supertest": "^2.0.10",
-    "mockdate": "^3.0.2",
-    "supertest": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^3.3.0",
+    "@typescript-eslint/parser": "^3.3.0",
     "eslint": "^7.3.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.21.2",
@@ -67,6 +65,8 @@
     "eslint-plugin-standard": "^4.0.1",
     "jest": "^26.1.0",
     "jest-junit": "^11.0.1",
+    "mockdate": "^3.0.2",
+    "supertest": "^5.0.0",
     "ts-jest": "^26.1.0",
     "typescript": "^3.9.5"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/express-did-auth",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Authentication with Verifiable Credentials for Express.js",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,10 @@ export default function setupAppFactory (config: ExpressDidAuthConfig) {
         res.status(403)
         res.send(CSRF_ERROR_MESSAGE)
       })
+
+      app.get('/refresh-csrf', (req, res) => {
+        res.status(200).send(req.csrfToken())
+      })
     }
 
     const authMiddleware = expressMiddlewareFactory(state, config)


### PR DESCRIPTION
Using cookies mode, when trying to authenticate to the RIF Data Vault using [this app](header https://email-verifier.identity.rifos.org/), the csrf token is not returned in the headers as it should. For example, in [this other app](https://identity.rifos.org/) the Data Vault login is working fine... I added this method enabling another way to get the csrf token.